### PR TITLE
fix: bump version of frms-coe-lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
+        "@tazama-lf/frms-coe-lib": "5.1.1-rc.0",
         "@tazama-lf/frms-coe-startup-lib": "2.4.0-rc.4",
         "dotenv": "^17.2.0",
         "tslib": "^2.8.1"
@@ -2174,6 +2174,42 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
+      "version": "5.1.1-rc.0",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.1.1-rc.0/5ea96ee51a1a167711de65b592b54dc50149167c",
+      "integrity": "sha512-pIMCT6BoGP0AzEOrHAJ1YdZMg0bJQRMQcJGDf1LUur0VpOh/OE3WIMCu2xLG6sSAFMKVcdx7ueflilZ7gNMx/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/ecs-pino-format": "^1.5.0",
+        "@grpc/grpc-js": "^1.13.4",
+        "@grpc/proto-loader": "^0.7.15",
+        "@types/uuid": "^10.0.0",
+        "arangojs": "^8.8.1",
+        "dotenv": "^17.2.0",
+        "elastic-apm-node": "^4.13.0",
+        "ioredis": "^5.6.1",
+        "node-cache": "^5.1.2",
+        "pino": "^9.7.0",
+        "pino-elasticsearch": "^8.1.0",
+        "protobufjs": "^7.5.3",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/@tazama-lf/frms-coe-startup-lib": {
+      "version": "2.4.0-rc.4",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/2.4.0-rc.4/1f564f95caa24d37caedbf28d38dd45e716a37da",
+      "integrity": "sha512-+sqnQpdJjqntk5t00Jp1+zLY5Nin9BjlyankrlvcSSIfmtZ7CCL3BlmCP8A2QQ9dJoDKm4CjwVPpgdPfm8guXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/bigquery": "^8.1.0",
+        "@google-cloud/storage": "^7.16.0",
+        "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
+        "amqplib": "^0.10.4",
+        "axios": "^1.8.2",
+        "google-auth-library": "^9.15.1",
+        "nats": "^2.28.2"
+      }
+    },
+    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/@tazama-lf/frms-coe-lib": {
       "version": "5.1.0-rc.7",
       "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/5.1.0-rc.7/20054645b8206233772f5637a57c77a76f88973c",
       "integrity": "sha512-t5/vXDsj4MRrQJCvOFmam6SYkWa/LSymiwFnaXL77vo7aIWy7eL+pwZuhE4YmdMF3JNBd2JR0kWuX5/wALS+ww==",
@@ -2194,7 +2230,7 @@
         "uuid": "^11.1.0"
       }
     },
-    "node_modules/@tazama-lf/frms-coe-lib/node_modules/dotenv": {
+    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
@@ -2204,21 +2240,6 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "2.4.0-rc.4",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/2.4.0-rc.4/1f564f95caa24d37caedbf28d38dd45e716a37da",
-      "integrity": "sha512-+sqnQpdJjqntk5t00Jp1+zLY5Nin9BjlyankrlvcSSIfmtZ7CCL3BlmCP8A2QQ9dJoDKm4CjwVPpgdPfm8guXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@google-cloud/bigquery": "^8.1.0",
-        "@google-cloud/storage": "^7.16.0",
-        "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
-        "amqplib": "^0.10.4",
-        "axios": "^1.8.2",
-        "google-auth-library": "^9.15.1",
-        "nats": "^2.28.2"
       }
     },
     "node_modules/@tokenizer/token": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "5.1.0-rc.7",
+    "@tazama-lf/frms-coe-lib": "5.1.1-rc.0",
     "@tazama-lf/frms-coe-startup-lib": "2.4.0-rc.4",
     "dotenv": "^17.2.0",
     "tslib": "^2.8.1"


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
bump frms-coe-lib version
## Why are we doing this?
fix types from alerts type
## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
