### PR TITLE
feat(service-channel): make-before-break re-subscribe on network-map reload (#424)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -35,6 +35,12 @@ EVALUATION_DATABASE_CERT_PATH=/usr/local/share/ca-certificates/ca-certificates.c
 SUPPRESS_ALERTS=false
 ALERTS_ONLY=false
 
+# Service Channel
+SERVICE_CHANNEL_CONSUMER=service-channel
+SERVICE_CHANNEL_PRODUCER=service-channel-ack
+SERVICE_CHANNEL_SOURCE_URI_PREFIX=
+SERVICE_CHANNEL_CLASS=event-adjudicator
+
 # Apm
 APM_SERVICE_NAME=event-adjudicator
 APM_ACTIVE=false

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ typings/
 # dotenv environment variables file
 *.env
 
+# Keys and certificates
+*.pem
+
 # next.js build output
 .next
 Katalon Tests/Profiles/

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,12 @@ ENV EVALUATION_DATABASE_CERT_PATH=/usr/local/share/ca-certificates/ca-certificat
 ENV SUPPRESS_ALERTS=false
 ENV ALERTS_ONLY=false
 
+# Service Channel
+ENV SERVICE_CHANNEL_CONSUMER=service-channel
+ENV SERVICE_CHANNEL_PRODUCER=service-channel-ack
+ENV SERVICE_CHANNEL_SOURCE_URI_PREFIX=
+ENV SERVICE_CHANNEL_CLASS=event-adjudicator
+
 # Apm
 ENV APM_ACTIVE=true
 ENV APM_URL=http://apm-server.development.svc.cluster.local:8200/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ A [registry](https://github.com/tazama-lf/docs/blob/f292c9ddabf52d6fe62addc1c619
 |----------------------------------------|---------------------------------------------|---------------------------|
 | `SUPPRESS_ALERTS`                      | Suppress forwarding report to NATS producer | `false`                   |
 | `ALERTS_ONLY`                          | When `true`, only forward reports with `status === 'ALRT'` to the NATS producer; when `false` (default), forward all completed evaluation results. Required - startup will fail if unset. Has no effect when `SUPPRESS_ALERTS=true`. | `false`                   |
+| `SERVICE_CHANNEL_CONSUMER`             | Forward subject subscribed to for service-channel events      | `service-channel`         |
+| `SERVICE_CHANNEL_PRODUCER`             | Reply subject acknowledgements are published to               | `service-channel-ack`     |
+| `SERVICE_CHANNEL_SOURCE_URI_PREFIX`    | Optional prefix for CloudEvents source composition            | `urn:tazama:`             |
+| `SERVICE_CHANNEL_CLASS`                | Required service-channel audience class for this service      | `event-adjudicator`       |
 | `RAW_HISTORY_DATABASE`                 | PostgreSQL database name                    | `raw_history`             |
 | `RAW_HISTORY_DATABASE_HOST`            | PostgreSQL hostname or endpoint             | `localhost`               |
 | `RAW_HISTORY_DATABASE_PORT`            | PostgreSQL post used                        | `5432`                    |
@@ -122,3 +126,16 @@ The output is the input with an added [tadpResult](https://github.com/tazama-lf/
   tadpResult: TADPResult;
 }
 ```
+
+## Service-channel receive seam
+At startup, event-adjudicator subscribes to the service-channel forward subject (`SERVICE_CHANNEL_CONSUMER`, default `service-channel`) and processes each received message through a validate, dispatch, re-subscribe pipeline.
+Incoming structured-mode CloudEvent bytes are decoded and the envelope is re-validated; a malformed message is dropped at `warn` without tearing down the subscription.
+The handler dispatches on the CloudEvent `type` verb (currently only `org.tazama.network-map.activated`); an unrecognised type is dropped at `warn`.
+An audience gate then applies: a message acts only when its `audience` is absent, `all`, this service's class (`event-adjudicator`), or its own function name, otherwise it is ignored at `debug`.
+For a valid, in-audience `network-map.activated` event, the full per-processor data-plane subject set is re-derived from the reloaded network map - keyed on `FUNCTION_NAME` and spanning every tenant - and handed to the additive seam, which subscribes only the new subjects and leaves existing subscriptions in place (the make-before-break half of a hot reload).
+Derivation is by processor, never by tenant: the trigger's `tenantId` is irrelevant here, so a different tenant (or none at all) yields the identical subject set and re-delivery is a safe idempotent no-op.
+Tearing down stale subscriptions is deliberately out of scope for this seam.
+After the matched handler runs, exactly one acknowledgement is published on the reply subject (`SERVICE_CHANNEL_PRODUCER`, default `service-channel-ack`): a CloudEvent reusing the trigger's `type` verb, with `source` composed as `${SERVICE_CHANNEL_SOURCE_URI_PREFIX}${FUNCTION_NAME}`, a fresh `id`, and `data` carrying the triggering event's `id` as `correlationId`, an `outcome` of `success` or `error`, and (on failure) the error message.
+The `source` composition assumes the service-channel audience class (`SERVICE_CHANNEL_CLASS`) is deployed to match `FUNCTION_NAME` (`event-adjudicator`); `validateServiceChannelConfiguration` fails startup fast if `SERVICE_CHANNEL_CLASS` is anything other than `event-adjudicator`.
+The handler returning normally yields an `outcome: success` ack and a throw yields an `outcome: error` ack, so each handled message produces exactly one ack publish attempt; a failed publish is logged and never tears down the subscription.
+This service runs one worker per CPU and each worker owns its own NATS connection, so a network-map reload produces one ack per worker; de-duplicating those acks is the responsibility of the publishing side, not this seam.

--- a/__tests__/unit/service-channel.service.test.ts
+++ b/__tests__/unit/service-channel.service.test.ts
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Service-channel env (subscribe on CONSUMER, ack on PRODUCER) must be in place before src/index is imported.
+process.env.SERVICE_CHANNEL_CONSUMER = 'service-channel';
+process.env.SERVICE_CHANNEL_PRODUCER = 'service-channel-ack';
+process.env.SERVICE_CHANNEL_SOURCE_URI_PREFIX = '';
+process.env.SERVICE_CHANNEL_CLASS = 'event-adjudicator';
+
+// Transport is mocked: the StartupFactory instance exposes the additive-subscribe seam (addConsumers)
+// and the ack publisher (publishServiceChannel) as jest mocks we can assert against.
+jest.mock('@tazama-lf/frms-coe-startup-lib', () => ({
+  StartupFactory: jest.fn(() => ({
+    init: jest.fn().mockResolvedValue(true),
+    initServiceChannel: jest.fn().mockResolvedValue(true),
+    publishServiceChannel: jest.fn().mockResolvedValue(undefined),
+    addConsumers: jest.fn().mockResolvedValue(true),
+  })),
+}));
+
+// The handler re-derives the full inbound subject set (the typology-processor tier's outputs) from the
+// freshly-loaded network map, keyed on FUNCTION_NAME and spanning every tenant.
+const DEFAULT_CONSUMERS = ['pub-typology-901', 'pub-typology-902'];
+jest.mock('@tazama-lf/frms-coe-lib/lib/helpers/networkMapIdentifiers', () => ({
+  getRoutesFromNetworkMap: jest.fn().mockResolvedValue({ consumers: ['pub-typology-901', 'pub-typology-902'] }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-lib/lib/services/dbManager', () => ({
+  CreateStorageManager: jest.fn().mockReturnValue({
+    db: {
+      getNetworkMap: jest.fn(),
+      addOneGetAll: jest.fn(),
+      getTypologyConfig: jest.fn(),
+      deleteKey: jest.fn(),
+      isReadyCheck: jest.fn().mockReturnValue({ nodeEnv: 'test' }),
+    },
+  }),
+}));
+
+jest.mock('@tazama-lf/frms-coe-startup-lib/lib/interfaces/iStartupConfig', () => ({
+  startupConfig: {
+    startupType: 'nats',
+    consumerStreamName: 'consumer',
+    serverUrl: 'server',
+    producerStreamName: 'producer',
+    functionName: 'producer',
+  },
+}));
+
+import { ServiceChannelType, SERVICE_CHANNEL_AUDIENCE } from '@tazama-lf/frms-coe-lib';
+import { getRoutesFromNetworkMap } from '@tazama-lf/frms-coe-lib/lib/helpers/networkMapIdentifiers';
+import { configuration, databaseManager, loggerService, runServer, server } from '../../src';
+import { validateServiceChannelConfiguration, type Configuration } from '../../src/config';
+import { handleExecute } from '../../src/services/logic.service';
+import { handleServiceChannelMessage } from '../../src/services/service-channel.service';
+
+const encode = (event: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(event));
+
+const buildEvent = (overrides: Record<string, unknown> = {}): Uint8Array =>
+  encode({
+    specversion: '1.0',
+    id: 'evt-1',
+    source: 'test://producer',
+    type: ServiceChannelType.NETWORK_MAP_ACTIVATED,
+    datacontenttype: 'application/json',
+    data: { cfg: '1.0.0', tenantId: 'tenant-A' },
+    ...overrides,
+  });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DecodedAck = { event: Record<string, any>; subject: string };
+
+const decodeAck = (call: unknown[]): DecodedAck => {
+  const [bytes, subject] = call as [Uint8Array, string];
+  return { event: JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>, subject } as DecodedAck;
+};
+
+const getRoutesMock = getRoutesFromNetworkMap as jest.Mock;
+let addConsumersMock: jest.Mock;
+let publishMock: jest.Mock;
+
+beforeAll(async () => {
+  // Populate the exported `server` live-binding (nodeEnv === 'test' short-circuits the connect/retry
+  // inside runServer) so the mocked transport seams are available for every awaited handler call.
+  await runServer();
+  addConsumersMock = server.addConsumers as unknown as jest.Mock;
+  publishMock = server.publishServiceChannel as unknown as jest.Mock;
+});
+
+describe('service-channel dispatch + additive re-subscribe (#424)', () => {
+  let warnSpy: jest.SpyInstance;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configuration.functionName = 'event-adjudicator';
+    configuration.SERVICE_CHANNEL_CLASS = SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR;
+    configuration.SERVICE_CHANNEL_PRODUCER = 'service-channel-ack';
+    configuration.SERVICE_CHANNEL_SOURCE_URI_PREFIX = '';
+    getRoutesMock.mockReset();
+    getRoutesMock.mockResolvedValue({ consumers: [...DEFAULT_CONSUMERS] });
+    addConsumersMock.mockReset();
+    addConsumersMock.mockResolvedValue(true);
+    publishMock.mockReset();
+    publishMock.mockResolvedValue(undefined);
+    jest.spyOn(loggerService, 'log').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(loggerService, 'warn').mockImplementation(() => undefined);
+    debugSpy = jest.spyOn(loggerService, 'debug').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('valid network-map.activated', () => {
+    it('re-derives the network-map subjects for this function and additively subscribes them', async () => {
+      await handleServiceChannelMessage(buildEvent());
+
+      expect(getRoutesMock).toHaveBeenCalledTimes(1);
+      expect(getRoutesMock).toHaveBeenCalledWith(databaseManager, configuration.functionName);
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).toHaveBeenCalledWith(DEFAULT_CONSUMERS, handleExecute);
+    });
+
+    it('passes the data-plane execute handler as the onMessage for the new subjects', async () => {
+      await handleServiceChannelMessage(buildEvent());
+
+      const [, onMessage] = addConsumersMock.mock.calls[0] as [string[], unknown];
+      expect(onMessage).toBe(handleExecute);
+    });
+
+    it('is a safe no-op on re-delivery, delegating idempotency to addConsumers', async () => {
+      getRoutesMock.mockResolvedValue({ consumers: [...DEFAULT_CONSUMERS] });
+
+      await handleServiceChannelMessage(buildEvent());
+      await expect(handleServiceChannelMessage(buildEvent())).resolves.toBeUndefined();
+
+      expect(addConsumersMock).toHaveBeenCalledTimes(2);
+      expect(addConsumersMock).toHaveBeenNthCalledWith(2, DEFAULT_CONSUMERS, handleExecute);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('re-subscribes the newly-added subjects when the reloaded map has grown', async () => {
+      getRoutesMock.mockResolvedValueOnce({ consumers: [...DEFAULT_CONSUMERS, 'pub-typology-903'] });
+
+      await handleServiceChannelMessage(buildEvent());
+
+      expect(addConsumersMock).toHaveBeenCalledWith(['pub-typology-901', 'pub-typology-902', 'pub-typology-903'], handleExecute);
+    });
+
+    it('derives by functionName for every event regardless of the tenantId, never keyed on tenant (no tenant gate)', async () => {
+      // EA re-derives the full per-processor inbound subject set; a different tenantId, or none at all,
+      // must yield the identical derivation and never drop. The event tenantId must not reach the helper.
+      await handleServiceChannelMessage(buildEvent({ data: { cfg: '1.0.0', tenantId: 'tenant-A' } }));
+      await handleServiceChannelMessage(buildEvent({ data: { cfg: '1.0.0' } }));
+
+      expect(getRoutesMock).toHaveBeenCalledTimes(2);
+      // Both deliveries derive on (databaseManager, functionName) only - no tenant arg is ever passed.
+      for (const call of getRoutesMock.mock.calls) {
+        expect(call).toEqual([databaseManager, configuration.functionName]);
+      }
+      expect(addConsumersMock).toHaveBeenCalledTimes(2);
+      expect(addConsumersMock).toHaveBeenNthCalledWith(1, DEFAULT_CONSUMERS, handleExecute);
+      expect(addConsumersMock).toHaveBeenNthCalledWith(2, DEFAULT_CONSUMERS, handleExecute);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('completes as a no-op (subscribes nothing) when the reloaded map has no routes', async () => {
+      getRoutesMock.mockResolvedValueOnce({ consumers: [] });
+
+      await expect(handleServiceChannelMessage(buildEvent())).resolves.toBeUndefined();
+
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).toHaveBeenCalledWith([], handleExecute);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('malformed input is dropped at warn without subscribing', () => {
+    it('drops non-JSON bytes', async () => {
+      await expect(handleServiceChannelMessage(new TextEncoder().encode('not-json'))).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).not.toHaveBeenCalled();
+    });
+
+    it('drops an envelope missing the required type attribute', async () => {
+      await expect(handleServiceChannelMessage(buildEvent({ type: undefined }))).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('unknown type is dropped at warn without subscribing', () => {
+    it('does not re-subscribe and does not throw', async () => {
+      await expect(handleServiceChannelMessage(buildEvent({ type: 'org.tazama.network-map.deactivated' }))).resolves.toBeUndefined();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audience gate', () => {
+    it('acts when audience is absent (broadcast default)', async () => {
+      await handleServiceChannelMessage(buildEvent());
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('acts when audience is the broadcast token', async () => {
+      await handleServiceChannelMessage(buildEvent({ audience: SERVICE_CHANNEL_AUDIENCE.ALL }));
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('acts when audience is its own class token', async () => {
+      await handleServiceChannelMessage(buildEvent({ audience: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR }));
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('acts when audience is its own function name (distinct from the class token)', async () => {
+      configuration.functionName = 'event-adjudicator-worker-1';
+
+      await handleServiceChannelMessage(buildEvent({ audience: 'event-adjudicator-worker-1' }));
+
+      expect(addConsumersMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores a message addressed to another tier at debug, without subscribing', async () => {
+      await handleServiceChannelMessage(buildEvent({ audience: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR }));
+
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).not.toHaveBeenCalled();
+    });
+
+    it('ignores an empty-string audience at debug (not broadcast), without subscribing', async () => {
+      await handleServiceChannelMessage(buildEvent({ audience: '' }));
+
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      expect(addConsumersMock).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('service-channel ack emission (#424)', () => {
+  let logSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    configuration.functionName = 'event-adjudicator';
+    configuration.SERVICE_CHANNEL_CLASS = SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR;
+    configuration.SERVICE_CHANNEL_PRODUCER = 'service-channel-ack';
+    configuration.SERVICE_CHANNEL_SOURCE_URI_PREFIX = '';
+    getRoutesMock.mockReset();
+    getRoutesMock.mockResolvedValue({ consumers: [...DEFAULT_CONSUMERS] });
+    addConsumersMock.mockReset();
+    addConsumersMock.mockResolvedValue(true);
+    publishMock.mockReset();
+    publishMock.mockResolvedValue(undefined);
+    logSpy = jest.spyOn(loggerService, 'log').mockImplementation(() => undefined);
+    jest.spyOn(loggerService, 'debug').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(loggerService, 'warn').mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(loggerService, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('publishes exactly one ack on the reply subject (SERVICE_CHANNEL_PRODUCER) after a successful handler', async () => {
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-success' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const { event, subject } = decodeAck(publishMock.mock.calls[0]);
+    expect(subject).toBe('service-channel-ack');
+    expect(event.type).toBe(ServiceChannelType.NETWORK_MAP_ACTIVATED);
+    expect(event.data.correlationId).toBe('evt-success');
+    expect(event.data.outcome).toBe('success');
+    expect(event.data.error).toBeUndefined();
+  });
+
+  it('mints a fresh ack id distinct from the triggering event id', async () => {
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-fresh-id' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const { event } = decodeAck(publishMock.mock.calls[0]);
+    expect(typeof event.id).toBe('string');
+    expect(event.id.length).toBeGreaterThan(0);
+    expect(event.id).not.toBe('evt-fresh-id');
+  });
+
+  it('composes the ack source as `${SERVICE_CHANNEL_SOURCE_URI_PREFIX}${FUNCTION_NAME}`', async () => {
+    configuration.SERVICE_CHANNEL_SOURCE_URI_PREFIX = 'tazama://acme/';
+    configuration.functionName = 'event-adjudicator-worker-7';
+
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-src' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const { event } = decodeAck(publishMock.mock.calls[0]);
+    expect(event.source).toBe('tazama://acme/event-adjudicator-worker-7');
+  });
+
+  it('publishes an outcome:error ack with data.error when the re-subscribe throws', async () => {
+    addConsumersMock.mockRejectedValueOnce(new Error('subscribe boom'));
+
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-error' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const { event } = decodeAck(publishMock.mock.calls[0]);
+    expect(event.type).toBe(ServiceChannelType.NETWORK_MAP_ACTIVATED);
+    expect(event.data.correlationId).toBe('evt-error');
+    expect(event.data.outcome).toBe('error');
+    expect(typeof event.data.error).toBe('string');
+    expect(event.data.error.length).toBeGreaterThan(0);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('publishes an outcome:error ack with data.error when re-deriving the network map fails', async () => {
+    getRoutesMock.mockRejectedValueOnce(new Error('network-map read boom'));
+
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-route-fail' }));
+
+    expect(addConsumersMock).not.toHaveBeenCalled();
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    const { event } = decodeAck(publishMock.mock.calls[0]);
+    expect(event.type).toBe(ServiceChannelType.NETWORK_MAP_ACTIVATED);
+    expect(event.data.correlationId).toBe('evt-route-fail');
+    expect(event.data.outcome).toBe('error');
+    expect(typeof event.data.error).toBe('string');
+    expect(event.data.error.length).toBeGreaterThan(0);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('sends exactly one ack on each of the success and error paths', async () => {
+    await handleServiceChannelMessage(buildEvent({ id: 'ok' }));
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(decodeAck(publishMock.mock.calls[0]).event.data.outcome).toBe('success');
+
+    addConsumersMock.mockRejectedValueOnce(new Error('boom'));
+    await handleServiceChannelMessage(buildEvent({ id: 'bad' }));
+    expect(publishMock).toHaveBeenCalledTimes(2);
+    expect(decodeAck(publishMock.mock.calls[1]).event.data.outcome).toBe('error');
+  });
+
+  describe('no ack on a pre-dispatch drop', () => {
+    it('does not ack malformed (non-JSON) bytes', async () => {
+      await handleServiceChannelMessage(new TextEncoder().encode('not-json'));
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it('does not ack an unknown type', async () => {
+      await handleServiceChannelMessage(buildEvent({ id: 'u', type: 'org.tazama.network-map.deactivated' }));
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it('does not ack a message addressed to another tier', async () => {
+      await handleServiceChannelMessage(buildEvent({ id: 'a', audience: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR }));
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('swallows a publish failure without throwing and logs at error', async () => {
+    publishMock.mockRejectedValueOnce(new Error('nats down'));
+
+    await expect(handleServiceChannelMessage(buildEvent({ id: 'evt-pubfail' }))).resolves.toBeUndefined();
+
+    // The handler itself succeeded (re-subscribe ran), so the only error source is the swallowed publish.
+    expect(addConsumersMock).toHaveBeenCalledTimes(1);
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('logs the successful ack at info (log), per the severity policy', async () => {
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-info' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(decodeAck(publishMock.mock.calls[0]).event.data.outcome).toBe('success');
+    expect(logSpy).toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not log the successful ack at warn or error', async () => {
+    await handleServiceChannelMessage(buildEvent({ id: 'evt-log' }));
+
+    expect(publishMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('validateServiceChannelConfiguration (#424)', () => {
+  it('throws fast when SERVICE_CHANNEL_CLASS is not event-adjudicator', () => {
+    const cfg = { ...configuration, SERVICE_CHANNEL_CLASS: SERVICE_CHANNEL_AUDIENCE.TYPOLOGY_PROCESSOR } as Configuration;
+    expect(() => {
+      validateServiceChannelConfiguration(cfg);
+    }).toThrow();
+  });
+
+  it('passes when SERVICE_CHANNEL_CLASS is event-adjudicator', () => {
+    const cfg = { ...configuration, SERVICE_CHANNEL_CLASS: SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR } as Configuration;
+    expect(() => {
+      validateServiceChannelConfiguration(cfg);
+    }).not.toThrow();
+  });
+});

--- a/cluster-setup.ts
+++ b/cluster-setup.ts
@@ -7,6 +7,11 @@ process.env.ALERTS_ONLY = 'false';
 process.env.ALERT_PRODUCER = 'stream';
 process.env.ALERT_DESTINATION = 'global';
 
+process.env.SERVICE_CHANNEL_CONSUMER = 'service-channel';
+process.env.SERVICE_CHANNEL_PRODUCER = 'service-channel-ack';
+process.env.SERVICE_CHANNEL_SOURCE_URI_PREFIX = '';
+process.env.SERVICE_CHANNEL_CLASS = 'event-adjudicator';
+
 process.env.APM_ACTIVE = 'false';
 process.env.APM_SERVICE_NAME = 'test';
 process.env.APM_URL = 'test';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "4.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.3",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.5",
         "dotenv": "^17.2.1",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.2.0-rc.1",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.1/763f21ed32311ac31a03779b2af2d75cf1c49b6e",
-      "integrity": "sha512-VUUQVNz12mHVjmOEwJSKtLRD/zQx0UBnZ3AxCnNkkUjFHK0nVJUtltdwkTApHlQnUbOR3emdEvjAYim21gFmmA==",
+      "version": "8.2.0-rc.2",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.2/e2a20f125673fdf42c11e76ef98de92698ccdfd2",
+      "integrity": "sha512-9eNMUxxkcSXs6OWfbB4ixXKPwixWgE0U+8jvTulh2rlvfCHpV5VRX0cx0K3grSniW6RKqlAHICMD0DRAtHH5Zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1887,12 +1887,12 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.3/0bfac0c45ca75f82905f1bd94035927bd3538e0e",
-      "integrity": "sha512-tvZTL+wvNM16CikJMnXuBCTzZLwop7qfKFVxorHVjpGvp7g8gl559Z8Rc514/5Qnrk0LyiwqZZtbJ7H+0JyErQ==",
+      "version": "3.1.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.5/240ea87c4ba7b48f039c781e756b542350d077d4",
+      "integrity": "sha512-58+aV59aj+95JF0aEqrkDXEQKx5JBiinCKgBEgglPSahsOTJC4YvC6SrXprLwaHumPm12N5Fc370IacyLEunhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "event-adjudicator",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-adjudicator",
-      "version": "4.0.0-rc.4",
+      "version": "4.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
-        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.5",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.7",
         "dotenv": "^17.2.1",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.2.0-rc.2",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.2/e2a20f125673fdf42c11e76ef98de92698ccdfd2",
-      "integrity": "sha512-9eNMUxxkcSXs6OWfbB4ixXKPwixWgE0U+8jvTulh2rlvfCHpV5VRX0cx0K3grSniW6RKqlAHICMD0DRAtHH5Zw==",
+      "version": "8.2.0-rc.3",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.3/2261d253248dfe63cbdb9445ba6786fad5ef17a4",
+      "integrity": "sha512-Kevho3L6RZvTNq5yBJE55smj3pkNmp5obUBcq/THOuHRxIzSoCQZJfbKH2bjYEOQkn2I+8FhUvyKje9eZJ2qaQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1887,12 +1887,12 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.1.0-rc.5",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.5/240ea87c4ba7b48f039c781e756b542350d077d4",
-      "integrity": "sha512-58+aV59aj+95JF0aEqrkDXEQKx5JBiinCKgBEgglPSahsOTJC4YvC6SrXprLwaHumPm12N5Fc370IacyLEunhA==",
+      "version": "3.1.0-rc.7",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.7/4baf4d53e1daea9369f3ddb5c6dded14422fe6b7",
+      "integrity": "sha512-MfwaPGfdXckSkH+9jJjc7NwCdTK8HqleJ+5iDt4x7q/QFMoEp3N0E3dwDKLZ5icCzG4jEhjFZfYAfBZXq+G3ew==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "event-adjudicator",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "event-adjudicator",
-      "version": "4.0.0-rc.3",
+      "version": "4.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.1.0-rc.0",
-        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.5",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+        "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.3",
         "dotenv": "^17.2.1",
         "tslib": "^2.8.1",
         "uuid": "^11.1.0"
@@ -1862,9 +1862,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.1.0-rc.0",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.1.0-rc.0/4c0582c8d7692c2522ece1fe6256f7904c661bf6",
-      "integrity": "sha512-z0vUYkAXYmew4atQEjValYPo/G5GFPiSjVjV3IkK733Ab63AwMO+n51z6/DiJSRTBs5pmjvNXhoLZtZ4LAqgAA==",
+      "version": "8.2.0-rc.1",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.2.0-rc.1/763f21ed32311ac31a03779b2af2d75cf1c49b6e",
+      "integrity": "sha512-VUUQVNz12mHVjmOEwJSKtLRD/zQx0UBnZ3AxCnNkkUjFHK0nVJUtltdwkTApHlQnUbOR3emdEvjAYim21gFmmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1872,6 +1872,7 @@
         "@grpc/proto-loader": "~0.7.15",
         "@types/pg": "^8.15.5",
         "@types/uuid": "^10.0.0",
+        "cloudevents": "^10.0.0",
         "dotenv": "^17.2.1",
         "elastic-apm-node": "^4.14.0",
         "ioredis": "^5.7.0",
@@ -1886,38 +1887,15 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.0.2-rc.5",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.5/dcec3157472b27cd8b274a9dffa6e3f1e7e59124",
-      "integrity": "sha512-Wb179bBsp42PhHJMw1EU2lHXGFITQcGCKozBcV6mi+fIGVxa8iKGGqUbV/ae9g84D45PU0sbRrLGJDqfxsacqw==",
+      "version": "3.1.0-rc.3",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.1.0-rc.3/0bfac0c45ca75f82905f1bd94035927bd3538e0e",
+      "integrity": "sha512-tvZTL+wvNM16CikJMnXuBCTzZLwop7qfKFVxorHVjpGvp7g8gl559Z8Rc514/5Qnrk0LyiwqZZtbJ7H+0JyErQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.0.0-rc.3",
+        "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"
-      }
-    },
-    "node_modules/@tazama-lf/frms-coe-startup-lib/node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.3/875069520a1710fff8de65d3788957c4302da9c0",
-      "integrity": "sha512-EATYohwL80vlTrtwGcY/JKIhSqeeu3iZYa6zDjMt4mjCNkvlF/t3NXCz+FCKhLdfkJIJyHrEbLGss0akAPdf/g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@elastic/ecs-pino-format": "^1.5.0",
-        "@grpc/grpc-js": "^1.13.4",
-        "@grpc/proto-loader": "~0.7.15",
-        "@types/pg": "^8.15.5",
-        "@types/uuid": "^10.0.0",
-        "dotenv": "^17.2.1",
-        "elastic-apm-node": "^4.14.0",
-        "ioredis": "^5.7.0",
-        "node-cache": "^5.1.2",
-        "pg": "8.16.3",
-        "pg-format": "^1.0.4",
-        "pino": "^9.9.0",
-        "pino-elasticsearch": "^8.1.0",
-        "protobufjs": "^7.5.5",
-        "uuid": "^11.1.1"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -2803,6 +2781,45 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/amqplib": {
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.6.tgz",
@@ -3097,7 +3114,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -3695,6 +3711,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cloudevents": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cloudevents/-/cloudevents-10.0.0.tgz",
+      "integrity": "sha512-uyzC+PpMMRawbouHO+3mlisr3QfEDObmo2pN4oTTF6dZncZgpIzdasZx0tRBFI1dMsqCLZZXMtz8cUuvYqHdbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "ajv-formats": "^2.1.1",
+        "json-bigint": "^1.0.0",
+        "process": "^0.11.10",
+        "util": "^0.12.4",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=20 <=24"
+      }
+    },
+    "node_modules/cloudevents/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/cloudevents/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/cloudevents/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -5091,7 +5156,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -5131,6 +5195,22 @@
       "dependencies": {
         "end-of-stream": "^1.4.1"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -5280,7 +5360,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -5397,7 +5476,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6009,6 +6087,22 @@
         "ioredis": "^5"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -6091,7 +6185,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6219,7 +6312,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -6304,7 +6396,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6400,7 +6491,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -8463,7 +8553,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8798,6 +8887,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-in-the-middle": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
@@ -9036,7 +9134,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10404,6 +10501,19 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -10559,7 +10669,6 @@
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
       "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-adjudicator",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "description": "Typology processor results are collected in the Event Adjudicator where an alert may be generated",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -26,8 +26,8 @@
   "author": "tazama",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.1.0-rc.0",
-    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.5",
+    "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.3",
     "dotenv": "^17.2.1",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "author": "tazama",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.2.0-rc.1",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.3",
+    "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.5",
     "dotenv": "^17.2.1",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "event-adjudicator",
-  "version": "4.0.0-rc.4",
+  "version": "4.0.0-rc.5",
   "description": "Typology processor results are collected in the Event Adjudicator where an alert may be generated",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -26,8 +26,8 @@
   "author": "tazama",
   "license": "Apache-2.0",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.2.0-rc.2",
-    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.5",
+    "@tazama-lf/frms-coe-lib": "8.2.0-rc.3",
+    "@tazama-lf/frms-coe-startup-lib": "3.1.0-rc.7",
     "dotenv": "^17.2.1",
     "tslib": "^2.8.1",
     "uuid": "^11.1.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // config settings, env variables
-import type { ManagerConfig } from '@tazama-lf/frms-coe-lib';
+import { SERVICE_CHANNEL_AUDIENCE, type ManagerConfig, type ServiceChannelAudienceClass } from '@tazama-lf/frms-coe-lib';
 import type { AdditionalConfig, ProcessorConfig } from '@tazama-lf/frms-coe-lib/lib/config/processor.config';
 import * as dotenv from 'dotenv';
 import * as path from 'node:path';
@@ -15,6 +15,10 @@ export interface ExtendedConfig {
   SUPPRESS_ALERTS: boolean;
   ALERTS_ONLY: boolean;
   ALERT_DESTINATION: 'global' | 'tenant';
+  SERVICE_CHANNEL_PRODUCER?: string;
+  SERVICE_CHANNEL_CONSUMER?: string;
+  SERVICE_CHANNEL_SOURCE_URI_PREFIX?: string;
+  SERVICE_CHANNEL_CLASS: ServiceChannelAudienceClass;
 }
 
 export const additionalEnvironmentVariables: AdditionalConfig[] = [
@@ -38,7 +42,33 @@ export const additionalEnvironmentVariables: AdditionalConfig[] = [
     type: 'string',
     optional: false,
   },
+  {
+    name: 'SERVICE_CHANNEL_PRODUCER',
+    type: 'string',
+    optional: true,
+  },
+  {
+    name: 'SERVICE_CHANNEL_CONSUMER',
+    type: 'string',
+    optional: true,
+  },
+  {
+    name: 'SERVICE_CHANNEL_SOURCE_URI_PREFIX',
+    type: 'string',
+    optional: true,
+  },
+  {
+    name: 'SERVICE_CHANNEL_CLASS',
+    type: 'string',
+    optional: false,
+  },
 ];
 
 export type DatabasesConfig = Required<Pick<ManagerConfig, 'configuration' | 'evaluation' | 'localCacheConfig' | 'redisConfig'>>;
 export type Configuration = ProcessorConfig & DatabasesConfig & ExtendedConfig;
+
+export const validateServiceChannelConfiguration = (configuration: Configuration): void => {
+  if (configuration.SERVICE_CHANNEL_CLASS !== SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR) {
+    throw new Error(`Environment variable SERVICE_CHANNEL_CLASS must be '${SERVICE_CHANNEL_AUDIENCE.EVENT_ADJUDICATOR}'.`);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,9 @@ import cluster from 'node:cluster';
 import os from 'node:os';
 import { setTimeout } from 'node:timers/promises';
 import * as util from 'node:util';
-import { additionalEnvironmentVariables, type Configuration } from './config';
+import { additionalEnvironmentVariables, type Configuration, validateServiceChannelConfiguration } from './config';
 import { handleExecute } from './services/logic.service';
+import { handleServiceChannelMessage } from './services/service-channel.service';
 import { Singleton } from './services/services';
 
 let configuration = validateProcessorConfig(additionalEnvironmentVariables) as Configuration;
@@ -31,6 +32,7 @@ export let server: IStartupService;
 export const runServer = async (): Promise<void> => {
   server = new StartupFactory();
   if (configuration.nodeEnv !== 'test') {
+    validateServiceChannelConfiguration(configuration);
     let isConnected = false;
     for (let retryCount = 0; retryCount < 10; retryCount++) {
       loggerService.log('Connecting to nats server...');
@@ -46,6 +48,16 @@ export const runServer = async (): Promise<void> => {
 
     if (!isConnected) {
       throw new Error('Unable to connect to nats after 10 retries');
+    }
+
+    const serviceChannelInitialized = await server.initServiceChannel!(
+      handleServiceChannelMessage,
+      configuration.SERVICE_CHANNEL_CONSUMER,
+      loggerService,
+    );
+
+    if (!serviceChannelInitialized) {
+      throw new Error('Unable to initialize service-channel subscription');
     }
   }
 };

--- a/src/services/service-channel.service.ts
+++ b/src/services/service-channel.service.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  construct,
+  deserialize,
+  validateEnvelope,
+  inAudience,
+  ServiceChannelType,
+  type NetworkMapActivatedData,
+} from '@tazama-lf/frms-coe-lib';
+import { getRoutesFromNetworkMap } from '@tazama-lf/frms-coe-lib/lib/helpers/networkMapIdentifiers';
+import type { CloudEvent } from 'cloudevents';
+import { configuration, databaseManager, loggerService, server } from '..';
+import { handleExecute } from './logic.service';
+import * as util from 'node:util';
+
+type ServiceChannelAckOutcome = 'success' | 'error';
+
+/** The reply payload echoed back on the producer subject: which trigger this acks and how it went. */
+interface ServiceChannelAckData {
+  correlationId: string;
+  outcome: ServiceChannelAckOutcome;
+  error?: string;
+}
+
+/**
+ * Make-before-break re-subscribe for a freshly-activated network map. The full per-processor subject
+ * set is re-derived from the reloaded map (keyed on FUNCTION_NAME, spanning every tenant) and handed
+ * to the additive seam, which subscribes only the new subjects and leaves existing subscriptions in
+ * place. The tenantId on the trigger is irrelevant here - derivation is by processor, never by tenant.
+ */
+const handleNetworkMapActivated = async (): Promise<void> => {
+  const { consumers } = await getRoutesFromNetworkMap(databaseManager, configuration.functionName);
+  await server.addConsumers!(consumers, handleExecute);
+  loggerService.log(`Re-subscribed ${consumers.length} data-plane consumer(s) after network-map reload`);
+};
+
+const dispatchTable: Record<string, (event: CloudEvent<NetworkMapActivatedData>) => void | Promise<void>> = {
+  [ServiceChannelType.NETWORK_MAP_ACTIVATED]: handleNetworkMapActivated,
+};
+
+/**
+ * Publish exactly one ack on the reply subject (`SERVICE_CHANNEL_PRODUCER`) after a handler runs. The
+ * ack is a service-channel CloudEvent reusing the trigger's `type` verb with this instance as `source`
+ * and `data` carrying the trigger's `id` as `correlationId`, the outcome, and (on failure) the error.
+ * Generic by design (the same on every consumer); it never inspects handler-internal semantics and
+ * never throws - a failed publish is logged so it cannot tear down the subscription.
+ */
+const emitAck = async (trigger: CloudEvent<NetworkMapActivatedData>, outcome: ServiceChannelAckOutcome, error?: string): Promise<void> => {
+  try {
+    const ack = construct<ServiceChannelAckData>({
+      type: trigger.type as ServiceChannelType,
+      source: `${configuration.SERVICE_CHANNEL_SOURCE_URI_PREFIX ?? ''}${configuration.functionName}`,
+      data: { correlationId: trigger.id, outcome, ...(error !== undefined ? { error } : {}) },
+    });
+    const bytes = new TextEncoder().encode(JSON.stringify(ack));
+    await server.publishServiceChannel!(bytes, configuration.SERVICE_CHANNEL_PRODUCER);
+    if (outcome === 'success') {
+      loggerService.log(`Acked ${trigger.type} on service channel (correlationId: ${trigger.id}, outcome: success)`);
+    } else {
+      loggerService.error(`Acked ${trigger.type} on service channel (correlationId: ${trigger.id}, outcome: error)`);
+    }
+  } catch (err) {
+    loggerService.error(`Failed to publish service-channel ack for ${trigger.type} (correlationId: ${trigger.id}): ${util.inspect(err)}`);
+  }
+};
+
+/**
+ * The service-channel receive seam: validate, dispatch, re-subscribe, then ack. Decodes the
+ * structured-mode CloudEvent bytes, re-checks the envelope, gates on audience, then dispatches on the
+ * `type` verb. Every pre-dispatch rejection drops the message without throwing (and without acking) so
+ * a single bad message can never tear down the subscription. Once a handler is matched, exactly one
+ * ack is published on the reply subject - `success` when the handler returns, `error` when it throws.
+ */
+export const handleServiceChannelMessage = async (data: Uint8Array): Promise<void> => {
+  let event: CloudEvent<NetworkMapActivatedData>;
+  try {
+    event = deserialize<NetworkMapActivatedData>(data);
+    validateEnvelope(event);
+  } catch (err) {
+    loggerService.warn(`Discarding malformed service-channel message: ${util.inspect(err)}`);
+    return;
+  }
+
+  const handler = dispatchTable[event.type];
+  if (!handler) {
+    loggerService.warn(`Discarding service-channel message of unknown type: ${event.type}`);
+    return;
+  }
+
+  const { audience } = event as unknown as { audience?: unknown };
+  if (
+    !inAudience(typeof audience === 'string' ? audience : undefined, {
+      class: configuration.SERVICE_CHANNEL_CLASS,
+      functionName: configuration.functionName,
+    })
+  ) {
+    loggerService.debug(
+      `Ignoring service-channel message not addressed to ${configuration.SERVICE_CHANNEL_CLASS} (audience: ${String(audience)})`,
+    );
+    return;
+  }
+
+  let outcome: ServiceChannelAckOutcome = 'success';
+  let ackError: string | undefined;
+  try {
+    await handler(event);
+  } catch (err) {
+    outcome = 'error';
+    ackError = err instanceof Error ? err.message : util.inspect(err);
+    loggerService.error(`Service-channel handler for ${event.type} failed: ${ackError}`);
+  }
+
+  await emitAck(event, outcome, ackError);
+};

--- a/src/services/service-channel.service.ts
+++ b/src/services/service-channel.service.ts
@@ -32,7 +32,7 @@ interface ServiceChannelAckData {
 const handleNetworkMapActivated = async (): Promise<void> => {
   const { consumers } = await getRoutesFromNetworkMap(databaseManager, configuration.functionName);
   await server.addConsumers!(consumers, handleExecute);
-  loggerService.log(`Re-subscribed ${consumers.length} data-plane consumer(s) after network-map reload`);
+  loggerService.log(`Additively subscribed ${consumers.length} data-plane consumer(s) after network-map reload`);
 };
 
 const dispatchTable: Record<string, (event: CloudEvent<NetworkMapActivatedData>) => void | Promise<void>> = {


### PR DESCRIPTION
## Summary

Resolves #424.

Adds the service-channel receive seam so **event-adjudicator** additively re-subscribes its data-plane consumers when a new network map is activated - the make-before-break half of a hot reload. This mirrors the typology-processor implementation (#436, shipped as PR #437), copying the source and swapping only env/identity tokens and the data-plane handler name.

## What changed

- **`src/services/service-channel.service.ts`** (new) - the receive seam: a `validate -> dispatch -> additive re-subscribe -> ack` pipeline.
  - Decodes structured-mode CloudEvent bytes and re-validates the envelope; a malformed message is dropped at `warn` without tearing down the subscription.
  - Dispatches on the CloudEvent `type` verb (currently only `org.tazama.network-map.activated`); an unknown type is dropped at `warn`.
  - Audience gate: acts only when `audience` is absent, `all`, this service's class (`event-adjudicator`), or its own function name; otherwise ignored at `debug`.
  - On a valid, in-audience event the full per-processor subject set is re-derived from the reloaded map (keyed on `FUNCTION_NAME`, spanning every tenant) and handed to the additive seam (`addConsumers`), which subscribes only the new subjects and leaves existing subscriptions in place. Derivation is by processor, never by tenant, so re-delivery is an idempotent no-op.
  - Publishes exactly one ack per handled message on `SERVICE_CHANNEL_PRODUCER` (`success`/`error`); a failed publish is logged and never tears down the subscription.
- **`src/index.ts`** - wires `validateServiceChannelConfiguration(configuration)` (fail-fast) before connect and `initServiceChannel(handleServiceChannelMessage, SERVICE_CHANNEL_CONSUMER, loggerService)` after connect, inside the existing `nodeEnv !== 'test'` guard.
- **`src/config.ts`** - 4 new `SERVICE_CHANNEL_*` env vars (`PRODUCER`/`CONSUMER`/`SOURCE_URI_PREFIX` optional, `CLASS` required) + `validateServiceChannelConfiguration` (throws unless `SERVICE_CHANNEL_CLASS === 'event-adjudicator'`).
- **`cluster-setup.ts`** - the 4 `SERVICE_CHANNEL_*` test env vars.
- **`package.json`** - bump `@tazama-lf/frms-coe-lib` 8.1.0-rc.0 -> 8.2.0-rc.1 and `@tazama-lf/frms-coe-startup-lib` 3.0.2-rc.5 -> 3.1.0-rc.3 for the `deserialize`/`construct`/`validateEnvelope`/`inAudience` and `addConsumers`/`initServiceChannel`/`publishServiceChannel` seams; package version 4.0.0-rc.3 -> 4.0.0-rc.4.
- **`.env.template`, `Dockerfile`, `README.md`** - document the 4 vars and the receive-seam behaviour.
- **`__tests__/unit/service-channel.service.test.ts`** (new) - 29 tests written red-first, covering dispatch + additive re-subscribe, idempotent re-delivery, tenant-agnostic derivation, malformed/unknown/out-of-audience drops, ack success/error/publish-failure paths, and the startup validator.

## Validation

- `npm test` - 53/53 pass (3 suites).
- `npm run lint:eslint` - 0 errors (pre-existing magic-number warnings + one accepted `no-unnecessary-condition` on the dispatch `!handler` guard, matching the existing `services.ts` warning and TP parity).
- `npm run build` - clean.
- `prettier --write` applied to changed files.

## Deliberate scope boundaries (TP parity)

- The startup wire-up in `runServer` (the `initServiceChannel`/validator calls) lives behind the `nodeEnv !== 'test'` guard and is **not** unit-asserted - it is unreachable in unit tests without refactoring `runServer`. TP #437 shipped the same way and relies on the manual post-publish integration pass; EA's own pre-existing data-plane `server.init(...)` is likewise not unit-tested. Kept parity.
- `collectCoverageFrom` is left unchanged (matching TP, which did not add its service-channel handler to enforced coverage). The handler is still fully exercised by the 29-test suite; it is simply outside the enforced allowlist.

## Issue link

This PR targets `dev`, so GitHub ignores closing keywords - #424 is linked manually via the PR **Development** sidebar. The issue will need to be closed manually (or when the change reaches the default branch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service channel messaging to handle network map activation events with automatic subscription management and audience-gated message processing.
  * Implemented acknowledgment system for service channel messages with outcome tracking and error handling.

* **Documentation**
  * Updated configuration documentation with service channel environment variables and processing pipeline details.

* **Chores**
  * Updated dependencies and bumped version to 4.0.0-rc.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->